### PR TITLE
Revert "Copy "parent" fields alongside the "regular" fields."

### DIFF
--- a/gsearch_solr/conf/schema.xml
+++ b/gsearch_solr/conf/schema.xml
@@ -636,10 +636,6 @@
    <copyField source="mods_title_ms" dest="concatted_titles_txt"/>
    <copyField source="pb_parent_title_Item_annotation_ms" dest="concatted_titles_txt"/>
 
-   <!-- Copy "parent" PBCore to "regular" PBCore, for consistent searching... -->
-   <copyField source="pb_parent_*_ms" dest="pb_*_ms"/>
-   <copyField source="pb_parent_*_ms" dest="pb_*_txt"/>
-
    <!-- "concatenated" date created field... -->
    <copyField source="collection_mods_dateCreated_mdt" dest="concatted_date_created_mdt"/>
    <copyField source="collection_mods_dateCreated_mdt" dest="concatted_date_mdt"/>


### PR DESCRIPTION
This reverts commit b0f53aeabb7a38a1a677553e15f4d6ef205d33c3.

The given copyFields don't actually work, so let's drop 'em to avoid
confusion.

They'll just avoid the issue by using the concatenated fields we already have.
